### PR TITLE
fix: disable caching in getpid

### DIFF
--- a/aworker_var.gypi
+++ b/aworker_var.gypi
@@ -198,6 +198,11 @@
       ['OS=="mac"', {
         'aworker_obj_dir': '<(PRODUCT_DIR)',
       }],
+      ['OS=="linux"', {
+        'aworker_source_files': [
+          'src/libc_override.cc',
+        ],
+      }],
     ],
   },
 }

--- a/src/libc_override.cc
+++ b/src/libc_override.cc
@@ -1,0 +1,17 @@
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <csignal>
+#include <cstdint>
+
+static inline int aworker__getpid() {
+  return syscall(__NR_getpid);
+}
+
+// disables glibc getpid caching.
+pid_t getpid(void) {
+  return aworker__getpid();
+}
+
+int raise(int sig) {
+  return kill(getpid(), sig);
+}


### PR DESCRIPTION
See https://man7.org/linux/man-pages/man2/getpid.2.html#:~:text=getpid()%20cached%20PIDs.