### PR TITLE
fix: remove redundant curl handle init

### DIFF
--- a/lib/fetch/body.js
+++ b/lib/fetch/body.js
@@ -108,6 +108,7 @@ function getHeaderValueParams(value) {
   return params;
 }
 
+const utf8Decoder = new TextDecoder('utf-8');
 class Body {
   #contentType;
   #size;
@@ -161,8 +162,7 @@ class Body {
     }
 
     const ab = await this.arrayBuffer();
-    const decoder = new TextDecoder('utf-8');
-    return decoder.decode(ab);
+    return utf8Decoder.decode(ab);
   }
 
   async json() {

--- a/lib/fetch/drivers/curl.js
+++ b/lib/fetch/drivers/curl.js
@@ -77,16 +77,19 @@ function createCurlError(code, message) {
 //                  and consisting of either *TEXT or combinations
 //                  of token, separators, and quoted-string>
 function parseHeaderLines(lines) {
-  const [ /* httpVersion */, statusCode, reason ] = lines[0].split(' ');
+  const { /* 0: httpVersion */ 1: statusCode, 2: reason } = lines[0].split(' ');
   const status = Number.parseInt(statusCode, 10);
   const statusText = reason.substring(0, -2);
-  const headers = [];
+  const headers = new Array(lines.length - 1);
   for (let idx = 1; idx < lines.length; idx++) {
-    const colonIdx = lines[idx].indexOf(':');
+    const line = lines[idx];
+    const colonIdx = line.indexOf(':');
     if (colonIdx === -1) {
+      // lenient fallback
+      headers[idx - 1] = [ line, '' ];
       continue;
     }
-    headers.push([ lines[idx].substring(0, colonIdx).trim(), lines[idx].substring(colonIdx + 1).trim() ]);
+    headers[idx - 1] = [ line.substring(0, colonIdx).trim(), line.substring(colonIdx + 1).trim() ];
   }
   return {
     status,
@@ -96,18 +99,17 @@ function parseHeaderLines(lines) {
 }
 
 class Curl {
-  #handle = new CurlEasy();
+  #handle;
 
   #remoteIp;
   #remotePort;
   #remoteFamily;
 
-  #headerDeferred = createDeferred();
+  #headerDeferred;
   #headerReceived = false;
   #responseHeaderLines = [];
 
   #responseBodyController;
-  #responseBody;
 
   #body;
   #bodyReader;
@@ -116,7 +118,7 @@ class Curl {
   #bodyPaused = false;
 
   #elu = eventLoopUtilization();
-  #timingInfo = {
+  timingInfo = {
     startTime: Date.now(),
   };
 
@@ -174,17 +176,17 @@ class Curl {
 
     const [ totalTime, namelookupTime, connectTime, appconnectTime, pretransferTime, starttransferTime, redirectTime ] = timingInfo;
 
-    this.#timingInfo.totalTime = totalTime / 1000;
-    this.#timingInfo.namelookupTime = namelookupTime / 1000;
-    this.#timingInfo.connectTime = connectTime / 1000;
-    this.#timingInfo.appconnectTime = appconnectTime / 1000;
-    this.#timingInfo.pretransferTime = pretransferTime / 1000;
-    this.#timingInfo.starttransferTime = starttransferTime / 1000;
-    this.#timingInfo.redirectTime = redirectTime / 1000;
+    this.timingInfo.totalTime = totalTime / 1000;
+    this.timingInfo.namelookupTime = namelookupTime / 1000;
+    this.timingInfo.connectTime = connectTime / 1000;
+    this.timingInfo.appconnectTime = appconnectTime / 1000;
+    this.timingInfo.pretransferTime = pretransferTime / 1000;
+    this.timingInfo.starttransferTime = starttransferTime / 1000;
+    this.timingInfo.redirectTime = redirectTime / 1000;
     const elu = eventLoopUtilization(this.#elu);
-    this.#timingInfo.eventLoopIdle = elu.idle;
-    this.#timingInfo.eventLoopActive = elu.active;
-    this.#timingInfo.eventLoopUtilization = elu.utilization;
+    this.timingInfo.eventLoopIdle = elu.idle;
+    this.timingInfo.eventLoopActive = elu.active;
+    this.timingInfo.eventLoopUtilization = elu.utilization;
 
     if (this.#bodyReader && !this.#bodyDone) {
       this.#bodyReader.cancel();
@@ -204,7 +206,7 @@ class Curl {
     }
   };
 
-  #abort = err => {
+  #abort(err) {
     if (this.#handle == null) {
       // Request is either aborted or done.
       return;
@@ -217,7 +219,7 @@ class Curl {
     this.#headerDeferred.reject(err);
     multi.removeHandle(this.#handle);
     this.#handle = null;
-  };
+  }
 
   constructor(url, method, headers, body, signal) {
     const multi = getMulti();
@@ -250,12 +252,14 @@ class Curl {
       this.drainBody();
     }
 
-    this.#responseBody = new ReadableStream({
+    this.responseBody = new ReadableStream({
       start: controller => {
         this.#responseBodyController = controller;
       },
     });
     this.#headerDeferred = createDeferred();
+    this.#headerReceived = false;
+    this.#responseHeaderLines = [];
 
     multi.addHandle(this.#handle);
 
@@ -326,10 +330,8 @@ class Curl {
   }
 
   /**
-   *
-   * @param {number} byteLength
-   * @param {Uint8Array} target
-   * @return
+   * @param {number} byteLength -
+   * @param {Uint8Array} target -
    */
   read(byteLength, target) {
     if (byteLength === 0) {
@@ -375,14 +377,6 @@ class Curl {
 
     return ret;
   }
-
-  getResponseBody() {
-    return this.#responseBody;
-  }
-
-  get timingInfo() {
-    return this.#timingInfo;
-  }
 }
 
 async function sendFetchReq(url, method, headers, body, signal) {
@@ -395,7 +389,7 @@ async function sendFetchReq(url, method, headers, body, signal) {
     status,
     statusText,
     headers: responseHeaders,
-    body: request.getResponseBody(),
+    body: request.responseBody,
     timingInfo: request.timingInfo,
   };
 }

--- a/lib/fetch/headers.js
+++ b/lib/fetch/headers.js
@@ -190,11 +190,10 @@ function validateValue(value) {
  */
 function dataAppend(data, key, value) {
   for (let i = 0; i < data.length; i++) {
-    const [ dataKey ] = data[i];
+    const { 0: dataKey, 1: dataValue } = data[i];
     if (key === 'set-cookie' && dataKey === 'set-cookie') {
-      const [ , dataValue ] = data[i];
-      const [ dataCookieKey ] = dataValue.split('=');
-      const [ cookieKey ] = value.split('=');
+      const { 0: dataCookieKey } = dataValue.split('=');
+      const { 0: cookieKey } = value.split('=');
       if (dataCookieKey === cookieKey) {
         data[i][1] = value;
         return;
@@ -257,13 +256,12 @@ function dataGet(data, key) {
  */
 function dataSet(data, key, value) {
   for (let i = 0; i < data.length; i++) {
-    const [ dataKey ] = data[i];
+    const { 0: dataKey, 1: dataValue } = data[i];
     if (dataKey === key) {
       // there could be multiple set-cookie headers, but all others are unique
       if (key === 'set-cookie') {
-        const [ , dataValue ] = data[i];
-        const [ dataCookieKey ] = dataValue.split('=');
-        const [ cookieKey ] = value.split('=');
+        const { 0: dataCookieKey } = dataValue.split('=');
+        const { 0: cookieKey } = value.split('=');
         if (cookieKey === dataCookieKey) {
           data[i][1] = value;
           return;
@@ -280,7 +278,7 @@ function dataSet(data, key, value) {
 function dataDelete(data, key) {
   let i = 0;
   while (i < data.length) {
-    const [ dataKey ] = data[i];
+    const { 0: dataKey } = data[i];
     if (dataKey === key) {
       data.splice(i, 1);
     } else {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -30,10 +30,6 @@ const { assert, AssertionError } = load('assert');
 const { createDeferred } = load('utils');
 const { structuredClone } = loadBinding('serdes');
 
-function setFunctionName(fn, value) {
-  Object.defineProperty(fn, 'name', { value, configurable: true });
-}
-
 const sym = {
   abortAlgorithm: Symbol('abortAlgorithm'),
   abortSteps: Symbol('abortSteps'),
@@ -2235,13 +2231,11 @@ function setUpReadableByteStreamControllerFromUnderlyingSource(
     0,
     controller
   );
-  setFunctionName(pullAlgorithm, '[[pullAlgorithm]]');
   const cancelAlgorithm = createAlgorithmFromUnderlyingMethod(
     underlyingByteSource,
     'cancel',
     1
   );
-  setFunctionName(cancelAlgorithm, '[[cancelAlgorithm]]');
   // 3.13.27.6 Let autoAllocateChunkSize be ? GetV(underlyingByteSource, "autoAllocateChunkSize").
   const autoAllocateChunkSize = undefined;
   setUpReadableByteStreamController(
@@ -2311,13 +2305,11 @@ function setUpReadableStreamDefaultControllerFromUnderlyingSource(
     0,
     controller
   );
-  setFunctionName(pullAlgorithm, '[[pullAlgorithm]]');
   const cancelAlgorithm = createAlgorithmFromUnderlyingMethod(
     underlyingSource,
     'cancel',
     1
   );
-  setFunctionName(cancelAlgorithm, '[[cancelAlgorithm]]');
   setUpReadableStreamDefaultController(
     stream,
     controller,
@@ -2454,19 +2446,16 @@ function setUpWritableStreamDefaultControllerFromUnderlyingSink(
     1,
     controller
   );
-  setFunctionName(writeAlgorithm, '[[writeAlgorithm]]');
   const closeAlgorithm = createAlgorithmFromUnderlyingMethod(
     underlyingSink,
     'close',
     0
   );
-  setFunctionName(closeAlgorithm, '[[closeAlgorithm]]');
   const abortAlgorithm = createAlgorithmFromUnderlyingMethod(
     underlyingSink,
     'abort',
     1
   );
-  setFunctionName(abortAlgorithm, '[[abortAlgorithm]]');
   setUpWritableStreamDefaultController(
     stream,
     controller,

--- a/lib/task_queue.js
+++ b/lib/task_queue.js
@@ -1,18 +1,24 @@
 'use strict';
 
 const { performMicrotaskCheckpoint } = loadBinding('task_queue');
+const {
+  private_symbols: {
+    async_context_mapping_symbol,
+  },
+} = loadBinding('constants');
 const { processUnhandledRejection } = load('process/execution');
 
 const kRootExecutionResource = new (class RootExecutionResource {})();
-const executionResourceStack = [];
-const resourceMapping = new WeakMap();
+let executionResourceStackIdx = 0;
+const kExecutionResourceStackMaxLength = 1024;
+const executionResourceStack = new Array(kExecutionResourceStackMaxLength);
 
 class AsyncLocalStorage {
   // Propagate the context from a parent resource to a child one
   static initHook(resource) {
     const currentResource = getExecutionResource();
-    const mapping = resourceMapping.get(currentResource);
-    resourceMapping.set(resource, mapping);
+    const mapping = currentResource[async_context_mapping_symbol];
+    resource[async_context_mapping_symbol] = mapping;
   }
 
   disable() {
@@ -26,21 +32,21 @@ class AsyncLocalStorage {
     }
 
     const resource = getExecutionResource();
-    const globalMapping = resourceMapping.get(resource);
+    const globalMapping = resource[async_context_mapping_symbol];
     const snapshot = new Map(globalMapping?.entries());
     snapshot.set(this, store);
-    resourceMapping.set(resource, snapshot);
+    resource[async_context_mapping_symbol] = snapshot;
 
     try {
       return Reflect.apply(callback, null, args);
     } finally {
-      resourceMapping.set(resource, globalMapping);
+      resource[async_context_mapping_symbol] = globalMapping;
     }
   }
 
   getStore() {
     const resource = getExecutionResource();
-    const globalMapping = resourceMapping.get(resource);
+    const globalMapping = resource[async_context_mapping_symbol];
     if (globalMapping == null) {
       return undefined;
     }
@@ -54,12 +60,15 @@ function asyncInit(resource) {
 }
 
 function asyncBefore(resource) {
-  executionResourceStack.push(resource);
+  if (executionResourceStackIdx >= kExecutionResourceStackMaxLength) {
+    return;
+  }
+  executionResourceStack[executionResourceStackIdx++] = resource;
   // TODO: schedule inspector async tasks;
 }
 
 function asyncAfter() {
-  executionResourceStack.pop();
+  executionResourceStack[--executionResourceStackIdx] = undefined;
   // TODO: schedule inspector async tasks;
 }
 
@@ -74,10 +83,10 @@ function callbackTrampoline(callback, ...args) {
 }
 
 function getExecutionResource() {
-  if (executionResourceStack.length === 0) {
+  if (executionResourceStackIdx === 0) {
     return kRootExecutionResource;
   }
-  return executionResourceStack[executionResourceStack.length - 1];
+  return executionResourceStack[executionResourceStackIdx - 1];
 }
 
 /**

--- a/lib/url/url.js
+++ b/lib/url/url.js
@@ -255,13 +255,8 @@ class URL {
   constructor(url, ...args) {
     url = String(url);
 
-    let base;
-    if (args.length >= 1) {
-      base = args[0];
-    }
-
-    if (base != null) {
-      this[kURLUrl] = parseUrl(url, String(base));
+    if (args[0] != null) {
+      this[kURLUrl] = parseUrl(url, String(args[0]));
     } else {
       this[kURLUrl] = parseUrl(url);
     }

--- a/src/binding/curl/curl_easy.cc
+++ b/src/binding/curl/curl_easy.cc
@@ -156,7 +156,7 @@ CurlEasy::CurlEasy(Immortal* immortal, Local<Object> obj)
   struct curl_blob blob;
   blob.data = root_certs;
   blob.len = strlen(root_certs);
-  blob.flags = CURL_BLOB_COPY;
+  blob.flags = CURL_BLOB_NOCOPY;
   curl_easy_setopt(easy_handle_, CURLOPT_CAINFO_BLOB, &blob);
 
   curl_easy_setopt(easy_handle_, CURLOPT_HEADERDATA, this);

--- a/src/immortal.h
+++ b/src/immortal.h
@@ -147,6 +147,7 @@ class KVStore {
   V(v8::Function, promise_resolve_hook)
 
 #define PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)                               \
+  V(async_context_mapping, "aworker:async_context_mapping")                    \
   V(contextify_global_private, "aworker:contextify:global")
 
 #define PER_ISOLATE_STRING_PROPERTIES(V)                                       \

--- a/src/snapshot/snapshot_builder.cc
+++ b/src/snapshot/snapshot_builder.cc
@@ -341,7 +341,6 @@ void SnapshotBuilder::Generate(SnapshotData* out,
        */
       immortal->Bootstrap();
       CHECK_EQ(immortal->tracked_handle_wraps.size(), 0);
-      CHECK_EQ(immortal->tracked_base_objects.size(), 0);
       std::string filename = immortal->commandline_parser()->script_filename();
       if (!filename.empty()) {
         immortal->BootstrapPerExecution();


### PR DESCRIPTION
Fixes: AONE#50157296

- Replaces the WeakMap in `asyncInit` with private symbols to improve performance.
- Avoids copying curl CAINFO_BLOB.